### PR TITLE
Add support for registering plugins if they are at the root of the project directory

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -270,7 +270,7 @@ class Installer extends LibraryInstaller
      *
      * @return array|null
      */
-    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $userVendorPath = true)
+    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $useRoot = false)
     {
         $autoload = $package->getAutoload();
 
@@ -288,12 +288,13 @@ class Installer extends LibraryInstaller
                 continue;
             }
 
+
             // Normalize $path to an absolute path
             if (!$fs->isAbsolutePath($path)) {
-                if ($userVendorPath === true) {
+                if ($useRoot === false) {
                     $path = $this->vendorDir . '/' . $package->getPrettyName() . '/' . $path;
                 } else {
-                    // TODO: Determine path
+                    $path = dirname($this->vendorDir) . '/' . $path;
                 }
             }
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -91,6 +91,7 @@ class Installer extends LibraryInstaller
 
     /**
      * @param PackageInterface $package
+     * @param bool|null $useRoot
      * @throws InvalidPluginException() if there's an issue with the plugin
      */
     public function addPlugin(PackageInterface $package, bool $useRoot = null)
@@ -265,9 +266,9 @@ class Installer extends LibraryInstaller
 
     /**
      * @param PackageInterface $package
-     * @param                  $class
-     * @param                  $basePath
-     *
+     * @param $class
+     * @param $basePath
+     * @param bool|null $useRoot
      * @return array|null
      */
     protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $useRoot = null)

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -270,7 +270,7 @@ class Installer extends LibraryInstaller
      *
      * @return array|null
      */
-    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath)
+    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $userVendorPath = true)
     {
         $autoload = $package->getAutoload();
 
@@ -290,7 +290,11 @@ class Installer extends LibraryInstaller
 
             // Normalize $path to an absolute path
             if (!$fs->isAbsolutePath($path)) {
-                $path = $this->vendorDir.'/'.$package->getPrettyName().'/'.$path;
+                if ($userVendorPath === true) {
+                    $path = $this->vendorDir . '/' . $package->getPrettyName() . '/' . $path;
+                } else {
+                    // TODO: Determine path
+                }
             }
 
             $path = $fs->normalizePath($path);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -93,7 +93,7 @@ class Installer extends LibraryInstaller
      * @param PackageInterface $package
      * @throws InvalidPluginException() if there's an issue with the plugin
      */
-    protected function addPlugin(PackageInterface $package)
+    public function addPlugin(PackageInterface $package)
     {
         $extra = $package->getExtra();
         $prettyName = $package->getPrettyName();

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -93,7 +93,7 @@ class Installer extends LibraryInstaller
      * @param PackageInterface $package
      * @throws InvalidPluginException() if there's an issue with the plugin
      */
-    public function addPlugin(PackageInterface $package)
+    public function addPlugin(PackageInterface $package, bool $useRoot = null)
     {
         $extra = $package->getExtra();
         $prettyName = $package->getPrettyName();
@@ -101,7 +101,7 @@ class Installer extends LibraryInstaller
         // Find the PSR-4 autoload aliases, the primary Plugin class, and base path
         $class = isset($extra['class']) ? $extra['class'] : null;
         $basePath = isset($extra['basePath']) ? $extra['basePath'] : null;
-        $aliases = $this->generateDefaultAliases($package, $class, $basePath);
+        $aliases = $this->generateDefaultAliases($package, $class, $basePath, $useRoot);
 
         // class + basePath (required)
         if ($class === null) {
@@ -270,7 +270,7 @@ class Installer extends LibraryInstaller
      *
      * @return array|null
      */
-    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $useRoot = false)
+    protected function generateDefaultAliases(PackageInterface $package, &$class, &$basePath, bool $useRoot = null)
     {
         $autoload = $package->getAutoload();
 
@@ -287,14 +287,12 @@ class Installer extends LibraryInstaller
                 // Yii doesn't support aliases that point to multiple base paths
                 continue;
             }
-
-
             // Normalize $path to an absolute path
             if (!$fs->isAbsolutePath($path)) {
-                if ($useRoot === false) {
-                    $path = $this->vendorDir . '/' . $package->getPrettyName() . '/' . $path;
-                } else {
+                if ($useRoot === true) {
                     $path = dirname($this->vendorDir) . '/' . $path;
+                } else {
+                    $path = $this->vendorDir . '/' . $package->getPrettyName() . '/' . $path;
                 }
             }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -31,7 +31,6 @@ class Plugin implements PluginInterface
 
         // At root?
         if ($composer->getPackage()->getType() === 'craft-plugin') {
-            // TODO: Make public
             $installer->addPlugin($composer->getPackage());
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -29,8 +29,8 @@ class Plugin implements PluginInterface
         $installer = new Installer($io, $composer);
         $composer->getInstallationManager()->addInstaller($installer);
 
-        // At root?
-        if ($composer->getPackage()->getType() === 'craft-plugin') {
+        // Is this a plugin at root? Elementary, my dear Watson 🕵️!
+        if ($installer->supports($composer->getPackage()->getType())) {
           $installer->addPlugin($composer->getPackage(), true);
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,5 +28,11 @@ class Plugin implements PluginInterface
         // Register the plugin installer
         $installer = new Installer($io, $composer);
         $composer->getInstallationManager()->addInstaller($installer);
+
+        // At root?
+        if ($composer->getPackage()->getType() === 'craft-plugin') {
+            // TODO: Make public
+            $installer->addPlugin($composer->getPackage());
+        }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -31,7 +31,7 @@ class Plugin implements PluginInterface
 
         // At root?
         if ($composer->getPackage()->getType() === 'craft-plugin') {
-            $installer->addPlugin($composer->getPackage());
+          $installer->addPlugin($composer->getPackage(), true);
         }
     }
 }


### PR DESCRIPTION
(As discussed on Notion)

As part of `craftcms/cms:feature-tests` we need to add support for registering plugins in `plugins.php` if they are at the root of a project. 

This is a concept proposal that adds support for this. 